### PR TITLE
feat(todos-api): migrate from in-memory cache to MongoDB

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,28 @@ services:
     networks:
       - microservices-network
 
+  # MongoDB - NoSQL Database
+  mongodb:
+    image: mongo:6.0
+    container_name: mongodb
+    ports:
+      - "${MONGO_PORT}:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
+      - MONGO_INITDB_DATABASE=${MONGO_DB_NAME}
+    volumes:
+      - mongodb_data:/data/db
+      - mongodb_config:/data/configdb
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - microservices-network
+
   # ===========================================
   # MICROSERVICES
   # ===========================================
@@ -82,9 +104,13 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
-      - REDIS_CHANNEL=${REDIS_CHANNEL} 
+      - REDIS_CHANNEL=${REDIS_CHANNEL}
+      - MONGO_URL=${MONGO_URL}
+      - MONGO_DB_NAME=${MONGO_DB_NAME}
     depends_on:
       redis:
+        condition: service_healthy
+      mongodb:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -139,4 +165,8 @@ networks:
 # ===========================================
 volumes:
   redis_data:
+    driver: local
+  mongodb_data:
+    driver: local
+  mongodb_config:
     driver: local

--- a/todos-api/Dockerfile
+++ b/todos-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.17.0-alpine
+FROM node:14.21.3-alpine
 
 WORKDIR /app
 

--- a/todos-api/package.json
+++ b/todos-api/package.json
@@ -10,14 +10,15 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.18.2",
-    "express": "^4.15.4",
+    "express": "^4.16.2",
     "express-jwt": "^5.3.0",
-    "memory-cache": "^0.2.0",
+    "mongodb": "^4.17.2",
     "redis": "^2.8.0",
-    "zipkin": "^0.11.2",
-    "zipkin-context-cls": "^0.11.0",
-    "zipkin-instrumentation-express": "^0.11.2",
-    "zipkin-transport-http": "^0.11.2"
+    "zipkin": "^0.11.1",
+    "zipkin-context-cls": "^0.6.1",
+    "zipkin-instrumentation-express": "^0.11.0",
+    "zipkin-instrumentation-redis": "^0.11.0",
+    "zipkin-transport-http": "^0.11.1"
   },
   "devDependencies": {
     "nodemon": "^1.11.0"

--- a/todos-api/routes.js
+++ b/todos-api/routes.js
@@ -1,7 +1,7 @@
 'use strict';
 const TodoController = require('./todoController');
-module.exports = function (app, {tracer, redisClient, logChannel}) {
-  const todoController = new TodoController({tracer, redisClient, logChannel});
+module.exports = function (app, {tracer, redisClient, logChannel, db}) {
+  const todoController = new TodoController({tracer, redisClient, logChannel, db});
   app.route('/todos')
     .get(function(req,resp) {return todoController.list(req,resp)})
     .post(function(req,resp) {return todoController.create(req,resp)});

--- a/todos-api/server.js
+++ b/todos-api/server.js
@@ -2,6 +2,7 @@
 const express = require('express')
 const bodyParser = require("body-parser")
 const jwt = require('express-jwt')
+const { MongoClient } = require('mongodb')
 
 const ZIPKIN_URL = process.env.ZIPKIN_URL || 'http://127.0.0.1:9411/api/v2/spans';
 const {Tracer, 
@@ -29,6 +30,26 @@ const redisClient = require("redis").createClient({
       return Math.min(options.attempt * 100, 2000);
   }        
 });
+
+// MongoDB configuration
+const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017';
+const mongoDbName = process.env.MONGO_DB_NAME || 'todosdb';
+let mongoClient;
+let db;
+
+// Initialize MongoDB connection
+async function initMongoDB() {
+  try {
+    mongoClient = new MongoClient(mongoUrl);
+    await mongoClient.connect();
+    db = mongoClient.db(mongoDbName);
+    console.log('Connected to MongoDB successfully');
+  } catch (error) {
+    console.error('Failed to connect to MongoDB:', error);
+    process.exit(1);
+  }
+}
+
 const port = process.env.TODO_API_PORT || 8082
 const jwtSecret = process.env.JWT_SECRET || "foo"
 
@@ -57,8 +78,24 @@ app.use(bodyParser.urlencoded({ extended: false }))
 app.use(bodyParser.json())
 
 const routes = require('./routes')
-routes(app, {tracer, redisClient, logChannel})
 
-app.listen(port, function () {
-  console.log('todo list RESTful API server started on: ' + port)
-})
+// Initialize MongoDB and start server
+async function startServer() {
+  await initMongoDB();
+  routes(app, {tracer, redisClient, logChannel, db});
+  
+  app.listen(port, function () {
+    console.log(`todos-api listening on port ${port}!`);
+  });
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+  console.log('Shutting down gracefully...');
+  if (mongoClient) {
+    await mongoClient.close();
+  }
+  process.exit(0);
+});
+
+startServer().catch(console.error);


### PR DESCRIPTION
- Replace in-memory storage with MongoDB for persistent todo storage
- Update Dockerfile to use newer Node.js version
- Add MongoDB service to docker-compose
- Modify todoController to use async/await with MongoDB operations
- Update dependencies including express and zipkin packages